### PR TITLE
Add dynamic category filtering based on request thresholds

### DIFF
--- a/app/api/v1/moderate.py
+++ b/app/api/v1/moderate.py
@@ -55,6 +55,13 @@ async def moderate(request: Request, moderation_request: ModerationRequest) -> M
             # Get model name (use default if not provided)
             model_name = moderation_request.model or settings.default_model
 
+            # Extract requested categories from thresholds
+            # If thresholds provided, only return those categories
+            # If no thresholds, return all categories (backward compatible)
+            requested_categories = None
+            if moderation_request.thresholds:
+                requested_categories = list(moderation_request.thresholds.keys())
+
             # Process each input
             for input_item in moderation_request.inputs:
                 with timer() as item_timer:
@@ -64,6 +71,7 @@ async def moderate(request: Request, moderation_request: ModerationRequest) -> M
                             text=input_item.text,
                             model_name=model_name,
                             custom_thresholds=moderation_request.thresholds,
+                            requested_categories=requested_categories,
                         )
 
                         # Create result

--- a/app/services/moderation.py
+++ b/app/services/moderation.py
@@ -222,6 +222,7 @@ async def moderate_text(
     text: str,
     model_name: Optional[str] = None,
     custom_thresholds: Optional[Dict[str, float]] = None,
+    requested_categories: Optional[list] = None,
 ) -> tuple[bool, Dict[str, bool], Dict[str, float]]:
     """
     Moderate a single text input.
@@ -230,6 +231,7 @@ async def moderate_text(
         text: Text to moderate
         model_name: Model identifier (optional)
         custom_thresholds: Optional custom thresholds per category
+        requested_categories: Optional list of categories to return (filters output)
 
     Returns:
         tuple: (flagged, category_flags, scores)
@@ -239,5 +241,10 @@ async def moderate_text(
 
     # Apply thresholds
     flagged, category_flags = apply_thresholds(scores, custom_thresholds)
+
+    # Filter results if specific categories requested
+    if requested_categories is not None:
+        scores = {cat: scores[cat] for cat in requested_categories if cat in scores}
+        category_flags = {cat: category_flags[cat] for cat in requested_categories if cat in category_flags}
 
     return flagged, category_flags, scores


### PR DESCRIPTION
- Extract requested categories from thresholds parameter in moderate endpoint
- Filter scores and category flags to return only requested categories
- Maintain backward compatibility: no thresholds returns all 6 categories
- Support single or multiple category selection per request